### PR TITLE
chore: move devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-iran-map",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-iran-map",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@testing-library/react": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "react": ">=16"
   },
   "dependencies": {
+    "react-tooltip": "^5.25.0"
+  },
+  "devDependencies": {
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
@@ -50,7 +53,6 @@
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.1.0",
-    "react-tooltip": "^5.25.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
move dependencies to devDependencies cause to smaller bundler, remove unused packages